### PR TITLE
Use latest pandoc version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,13 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 ENV PATH="${PATH}:/opt/R/${R_VERSION}/bin/"
 
 # System requirements for R packages
-RUN yum -y install openssl-devel libicu-devel epel-release pandoc
+RUN yum -y install openssl-devel libicu-devel epel-release
+
+ENV PANDOC_VERSION=2.16.2
+
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz
+RUN tar xvzf pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz --strip-components 1 -C /usr/local
+RUN rm -rf pandoc-${PANDOC_VERSION}*
 
 RUN Rscript -e "install.packages(c('httr', 'jsonlite', 'logger', 'remotes', 'rmarkdown', 'dplyr', 'ggplot2'), repos = 'https://packagemanager.rstudio.com/all/__linux__/centos7/latest')"
 RUN Rscript -e "remotes::install_github('mdneuzerling/lambdr')"


### PR DESCRIPTION
Hi David, thanks a million for developing **lambdr** as well as writing [that detailed tutorial blogpost](https://mdneuzerling.com/post/serverless-on-demand-parametrised-r-markdown-reports-with-aws-lambda/)! I successfully build an API to knit an HTML page after following the steps.

I encountered an issue though - pandoc returns an error code (and thus fails to knit) when I first tried to run the lambda function. I found the pandoc rpm available in EPEL repository is v1.12.3 (https://pkgs.org/search/?q=pandoc), while **rmarkdown** requires pandoc >= 1.14 (https://packagemanager.rstudio.com/client/#/repos/1/packages/rmarkdown).

I then followed [the installing guide of pandoc](https://pandoc.org/installing.html) to install the latest version of pandoc (instead of `yum install pandoc`) and the error was mysteriously gone.

I am not sure if others encountered the same issue. Still, this PR states the method to install the latest version of pandoc. Great if this helps.






